### PR TITLE
Add error handling for print sequence

### DIFF
--- a/lib/star_ethernet.rb
+++ b/lib/star_ethernet.rb
@@ -3,6 +3,7 @@ require 'star_ethernet/printer'
 require 'star_ethernet/status'
 require 'star_ethernet/status_item'
 require 'star_ethernet/version'
+require 'star_ethernet/exceptions'
 
 module StarEthernet
 end

--- a/lib/star_ethernet/exceptions.rb
+++ b/lib/star_ethernet/exceptions.rb
@@ -1,0 +1,13 @@
+module StarEthernet
+  class PrinterError < StandardError
+    def initialize(statuses_message)
+      super(statuses_message)
+    end
+  end
+
+  class EtbCountUpFailed < PrinterError; end
+
+  class PrintFailed < EtbCountUpFailed; end
+
+  class PrinterOffline < PrinterError; end
+end

--- a/lib/star_ethernet/status.rb
+++ b/lib/star_ethernet/status.rb
@@ -2,25 +2,32 @@ require 'star_ethernet/status_item'
 
 module StarEthernet
   class StarEthernet::Status
-    def initialize
-      @statuses = []
-    end
+    attr_reader :status_items
 
-    def all_statuses
-      @statuses
+    def initialize(printer)
+      @printer = printer
+      @status_items = []
     end
 
     def current_status
-      @statuses.last
+      @status_items.last
     end
 
     def previous_status
-      @statuses[-2]
+      @status_items[-2]
     end
 
-    def set_status(status_data)
+    def set_status(status_data, purpose = '')
       current_status = StatusItem.decode_status(status_data)
-      @statuses.push(current_status)
+      current_status.purpose = purpose
+      @status_items.push(current_status)
+    end
+
+    def full_messages
+      <<~"EOS"
+      #{@printer.host} printer's statuses are
+      #{@status_items.map{ |status_item| status_item.message }.join("\n")}
+      EOS
     end
   end
 end

--- a/lib/star_ethernet/status_item.rb
+++ b/lib/star_ethernet/status_item.rb
@@ -1,24 +1,33 @@
 module StarEthernet
   class StatusItem
-    attr_reader :etb
+    attr_reader :statuses, :time
+    attr_writer :purpose
+    attr_accessor :etb
 
     def initialize(statuses: [])
-      @statues = statuses
+      @statuses = statuses
       @etb = nil
       @time = Time.now
+      @purpose = nil
     end
 
-    def has_errors?
-      false # todo
+    def offline?
+      @statuses.include?(PrinterStatus::Offline)
     end
 
-    def append_status(*statuses)
-      @statues.push(statuses)
+    def append_status(status)
+      @statuses.push(status)
     end
 
-    def set_etb(counter)
-      @etb = counter
+    def message
+      msg = @statuses.empty? ?
+        "[#{@time.to_s}] Normal status" :
+        "[#{@time.to_s}] #{@statuses.map{ |status| status.to_s }.join(', ')}"
+      msg += " etb:#{@etb}"
+      msg += " (#{@purpose})" if @purpose
+      msg
     end
+
 
     class HeaderStatus
       # todo
@@ -94,8 +103,7 @@ module StarEthernet
       byte7 = status_data[12..13].hex # todo
 
       byte8 = status_data[14..15].hex
-      etb = ((byte8 >> 1) & 0b00000111) + ((byte8 >> 2) & 0b00011000)
-      status_item.set_etb(etb)
+      status_item.etb = ((byte8 >> 1) & 0b00000111) + ((byte8 >> 2) & 0b00011000)
 
       byte9 = status_data[16..17].hex # todo
 

--- a/spec/star_ethernet/status_item_spec.rb
+++ b/spec/star_ethernet/status_item_spec.rb
@@ -1,0 +1,58 @@
+RSpec.describe StarEthernet::StatusItem do
+  describe '#message' do
+    context 'without any statuses' do
+      it 'returns normal status message' do
+        status_item = StarEthernet::StatusItem.decode_status([0x23, 0x86, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00].pack('C*'))
+
+        expect(status_item.message).to include('Normal status')
+      end
+    end
+
+    context 'with specific statues' do
+      it 'returns some statuses message' do
+        status_item = StarEthernet::StatusItem.decode_status([0x23, 0x86, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00].pack('C*'))
+
+        expect(status_item.message).to include('StarEthernet::StatusItem::PrinterStatus::Offline')
+      end
+    end
+  end
+
+  describe '#offline' do
+    context 'when printer is online' do
+      it 'returns false' do
+        status_item = StarEthernet::StatusItem.decode_status([0x23, 0x86, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00].pack('C*'))
+
+        expect(status_item.offline?).to eq(false)
+      end
+    end
+
+    context 'when printer is offline' do
+      it 'returns true' do
+        status_item = StarEthernet::StatusItem.decode_status([0x23, 0x86, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00].pack('C*'))
+
+        expect(status_item.offline?).to eq(true)
+      end
+    end
+  end
+
+  describe '#message' do
+    it 'returns statuses message' do
+      status_item = StarEthernet::StatusItem.decode_status([0x23, 0x86, 0x02, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00].pack('C*'))
+      status_item.purpose = 'purpose'
+
+      expect(status_item.message).to include('EtbCommandExecuted')
+      expect(status_item.message).to include('etb:1')
+      expect(status_item.message).to include('purpose')
+    end
+  end
+
+  describe '.decode_status' do
+    context 'when etb is set' do
+      it 'returns status_item which etb is set' do
+        status_item = StarEthernet::StatusItem.decode_status([0x23, 0x86, 0x02, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00].pack('C*'))
+
+        expect(status_item.etb).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add error handling for print sequence.

2 errors are handled by checking etb counts.

- error occurred before printing
- error occurred in printing